### PR TITLE
improve error msg for `goal clerk compile`

### DIFF
--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -754,6 +754,9 @@ var compileCmd = &cobra.Command{
 				// Check if from was specified, else use default
 				if account == "" {
 					account = accountList.getDefaultAccount()
+					if account == "" {
+						reportErrorln("cannot find a default account")
+					}
 					fmt.Printf("will use default account: %v\n", account)
 				}
 				signingAddressResolved := accountList.getAddressByName(account)

--- a/cmd/goal/clerk.go
+++ b/cmd/goal/clerk.go
@@ -755,7 +755,7 @@ var compileCmd = &cobra.Command{
 				if account == "" {
 					account = accountList.getDefaultAccount()
 					if account == "" {
-						reportErrorln("cannot find a default account")
+						reportErrorln("no default account set. set one with 'goal account -f' or specify an account with '-a'.")
 					}
 					fmt.Printf("will use default account: %v\n", account)
 				}


### PR DESCRIPTION
improve error message for `goal clerk compile`

when the default account doesn't exists, output a proper error message.